### PR TITLE
fix(docs): compatibilizar script.v7.js com CSV PT/EN + PapaParse e ajustar paths para Pages

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -6,15 +6,15 @@
   <title>BOM Criticidade — V7</title>
 
   <!-- Estilos -->
-  <link rel="stylesheet" href="styles.css" />
+  <link rel="stylesheet" href="./styles.css?v=1" />
 
-  <!-- Chart.js -->
+  <!-- Libs -->   
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
 
   <!-- Nosso script (build V7) -->
-  <script defer src="script.v7.js"></script>
+  <script defer src="./script.v7.js?v=1"></script>
 
-  <!-- Meta básica -->
   <meta name="description" content="Dashboard de criticidade de materiais para indústria de fertilizantes: análise de risco, lead time, custo, estoque e consumo."/>
 </head>
 <body>


### PR DESCRIPTION
Contexto
O GitHub Pages carregava a página, mas os gráficos não apareciam por incompatibilidade entre o CSV gerado pelo ETL (colunas em EN) e o dashboard (esperava PT) e por ausência do PapaParse para ler CSV no browser.

Mudanças

docs/script.v7.js

Suporte a nomes de colunas PT/EN (criticidade_engenharia/eng_crit, consumo_mensal/daily_consumption, etc.).

Conversões automáticas: consumo mensal a partir do diário; cobertura em meses a partir de coverage_days.

Loader de CSV com PapaParse (delimitador auto) e fallback de paths (./data/... e ../data/...).

docs/index.html

Inclusão do PapaParse CDN.

Ajuste de paths relativos (./script.v7.js, ./styles.css) e cache-buster (?v=1).

Resultado esperado

Dashboard carrega no GitHub Pages com os gráficos (Top 20, Hist Score, Lead×Custo, Pareto, Criticidade Eng., Consumo×Estoque) lendo docs/data/processed/criticidade.csv (ou a amostra).

Como testar

Acesse o Pages: https://jk-pascoal.github.io/bom-criticidade/.

Abra DevTools → Network e recarregue: ver criticidade.csv com status 200.

Verifique se o badge “BUILD V7” aparece e se os 6 gráficos renderizam.

Impacto

Sem breaking changes no ETL.

Front-end mais resiliente a variações de schema/delimitador do CSV.

Checklist

 PapaParse incluído no index.html

 script.v7.js mapeia PT/EN e faz conversões

 Paths corrigidos para /docs

